### PR TITLE
Downgrade to C++11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 test_lsh: fht_lsh.cpp fht_lsh.h test_lsh.cpp
-	g++ -Wall -Wextra -march=native -mtune=native -ftree-vectorize -funroll-loops -O3  -std=c++17 -c fht_lsh.cpp -o fht_lsh.o
-	g++ -Wall -Wextra -march=native -mtune=native -ftree-vectorize -funroll-loops -O3  -std=c++17 -o test_lsh test_lsh.cpp fht_lsh.o
+	g++ -Wall -Wextra -march=native -mtune=native -ftree-vectorize -funroll-loops -O3  -std=c++11 -c fht_lsh.cpp -o fht_lsh.o
+	g++ -Wall -Wextra -march=native -mtune=native -ftree-vectorize -funroll-loops -O3  -std=c++11 -o test_lsh test_lsh.cpp fht_lsh.o

--- a/fht_lsh.cpp
+++ b/fht_lsh.cpp
@@ -275,17 +275,8 @@ void FastHadamardLSH::hash_templated(const int16_t * const vv, int32_t * const r
     {
         v[i] = _mm256_loadu_si256((__m256i*)&vv[16 * i]);
     }
-    
 
-    // Here we use some C++17 magic.
-    // If we have more than 2 registers to operate on then we apply the Hadamard transform on 32 entries at a given time
-    // However, if we've got only 2 registers to operate on then we need to use different permutations 
-    // and we only apply the Hadamard transform on 16 entries at a given time.
-    //
-    // But we don't want to use a regular if! That's slow.
-    // Thankfully, if constexpr is a thing - it will throw away the branch that we don't care about in our template - 
-    // thus it lets us write simpler code, but get the benefits we want in the end. 
-    if constexpr(regs_ > 2) {
+    if (regs_ > 2) {
     	//h0 and h1 contains the Hadamard transforms of v[0] and v[1] on each iteration respectively.
     	__m256i h0, h1;
     	// Permute the 16-bit integers in the matrix


### PR DESCRIPTION
This is just to bring the bucketer in line with the variant that's in G6K. It seems silly to require C++17 when we only use it in one place (namely, the singular if constexpr). 

